### PR TITLE
Feature/fix scrutinizr warning

### DIFF
--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -37,7 +37,7 @@ class PurgeCommand extends Command
      *
      * @var array
      */
-    protected $configured_logging_level = [
+    protected $logging_level = [
         'console' => 6,
         'log'     => 6,
     ];
@@ -135,9 +135,9 @@ class PurgeCommand extends Command
         $this->fire_purge_events = $this->laravel->make('config')
                                                  ->get('garbageman.fire_purge_events', $this->fire_purge_events);
 
-        $this->configured_logging_level = $this->laravel->make('config')
+        $this->logging_level = $this->laravel->make('config')
                                                         ->get('garbageman.logging_level',
-                                                            $this->configured_logging_level);
+                                                            $this->logging_level);
 
         $schedule = $this->laravel->make('config')
                                   ->get('garbageman.schedule', []);
@@ -267,10 +267,10 @@ class PurgeCommand extends Command
      */
     protected function supposedToLogAtThisLevel($level, $type)
     {
-        if (!array_key_exists($type, $this->configured_logging_level)) {
+        if (!array_key_exists($type, $this->logging_level)) {
             return true;
         }
 
-        return $this->log_levels[$level] <= $this->configured_logging_level[$type];
+        return $this->log_levels[$level] <= $this->logging_level[$type];
     }
 }

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -136,8 +136,7 @@ class PurgeCommand extends Command
                                                  ->get('garbageman.fire_purge_events', $this->fire_purge_events);
 
         $this->logging_level = $this->laravel->make('config')
-                                                        ->get('garbageman.logging_level',
-                                                            $this->logging_level);
+                                             ->get('garbageman.logging_level', $this->logging_level);
 
         $schedule = $this->laravel->make('config')
                                   ->get('garbageman.schedule', []);

--- a/tests/Commands/PurgeCommandTest.php
+++ b/tests/Commands/PurgeCommandTest.php
@@ -200,6 +200,11 @@ class PurgeCommandTests extends TestCase
                               'NoneExisting' => 14,
                           ]);
 
+        // Newer versions of laravel style, so give it if not set
+        $this->output_formatter_mock->shouldReceive('hasStyle')
+                                    ->with('warning')
+                                    ->andReturn(false);
+
         $this->output_formatter_mock->shouldReceive('setStyle')
                                     ->once()
                                     ->withArgs([


### PR DESCRIPTION
Scrutinizr is throwing a warning about the variable below. This shortens it, and makes it more consistent with the name of the config file.

see https://scrutinizer-ci.com/g/spinen/laravel-garbage-man/issues/develop/files/src/Commands/PurgeCommand.php?orderField=path&order=asc&honorSelectedPaths=1#inspectioncomment-1730609216
