### PR TITLE
Feature/format code and a little clean up

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,10 @@ Install Garbage Man:
 
 The package uses the auto registration feature
 
+## Upgrading to 2.x from 1.x
+
+As for Laravel 5.4, the `fire` method on the dispatcher contract was deprecated in favor of `dispatch`, and as of 5.8 the `fire` method has been removed. Therefore, we have updated our code to use `dispatch`.  You will need to change `fire` with `dispatch` in the `config/garbageman.php` file.
+
 ## Using the command
 
 The command is registered with laravel as ```garbageman:purge```.  You can run it one of 2 ways...

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ The package uses the auto registration feature
 
 ## Upgrading to 2.x from 1.x
 
-As for Laravel 5.4, the `fire` method on the dispatcher contract was deprecated in favor of `dispatch`, and as of 5.8 the `fire` method has been removed. Therefore, we have updated our code to use `dispatch`.  You will need to change `fire` with `dispatch` in the `config/garbageman.php` file.
+As of Laravel 5.4, the `fire()` method on the dispatcher contract [was deprecated](https://laravel.com/docs/5.4/upgrade) in favor of `dispatch()`, and as of 5.8 the `fire()` method has been removed. Therefore, we have updated our code to use `dispatch()`.  You will need to change `fire()` to `dispatch()` in your `config/garbageman.php` file.
 
 ## Using the command
 

--- a/readme.md
+++ b/readme.md
@@ -66,11 +66,11 @@ Publish the package config file to `config/garbageman.php`:
 
 This file is fully documented.  You will need to make the changes to that file to suit your needs. There are 3 main configuration items...
 
-1. Fire purge events - Fire events on purge of each record.
+1. Dispatch purge events - Dispatch events on purge of each record.
 2. Logging level - Level to log.
 3. Schedule - Models & number of days to allow the soft deleted record to stay.
 
-### Fire purge events (fire\_purge\_events)
+### Dispatch purge events (dispatch\_purge\_events)
 
 Allow hook into the purge of each record by throwing events before & after deleting of each record. There are 2 events thrown:
 

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -91,9 +91,9 @@ class PurgeCommand extends Command
     /**
      * Create a new command instance.
      *
-     * @param Carbon     $carbon
+     * @param Carbon $carbon
      * @param Dispatcher $dispatcher
-     * @param Log        $log
+     * @param Log $log
      */
     public function __construct(Carbon $carbon, Dispatcher $dispatcher, Log $log)
     {
@@ -107,9 +107,9 @@ class PurgeCommand extends Command
     /**
      * Fire the given event for the record being purged.
      *
-     * @param string    $event
-     * @param string    $model_name
-     * @param Model     $model
+     * @param string $event
+     * @param string $model_name
+     * @param Model $model
      * @param bool|null $halt
      *
      * @return mixed
@@ -154,7 +154,7 @@ class PurgeCommand extends Command
      * Purge the expired records.
      *
      * @param string $model
-     * @param int    $days
+     * @param int $days
      *
      * @return int|boolean
      */
@@ -182,7 +182,12 @@ class PurgeCommand extends Command
         $count = $this->purgeRecordsAsConfigured($query, $model);
 
         $this->recordMessage(
-            sprintf("Purged %s record(s) for %s that was deleted before %s days ago.", $count, $model, $expiration->toIso8601String())
+            sprintf(
+                "Purged %s record(s) for %s that was deleted before %s days ago.",
+                $count,
+                $model,
+                $expiration->toIso8601String()
+            )
         );
 
         return $count;
@@ -194,7 +199,7 @@ class PurgeCommand extends Command
      * This is to allow events to get fired for each record if needed.
      *
      * @param Builder $query
-     * @param string  $model_name
+     * @param string $model_name
      *
      * @return int
      */
@@ -224,7 +229,7 @@ class PurgeCommand extends Command
     /**
      * Log the action that was taken on the record.
      *
-     * @param string      $message
+     * @param string $message
      * @param string|null $level
      *
      * @return void

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -199,7 +199,7 @@ class PurgeCommand extends Command
     /**
      * Either purge all the records at once or loop through them one by one.
      *
-     * This is to allow events to get dispatchd for each record if needed.
+     * This is to allow events to get dispatched for each record if needed.
      *
      * @param Builder $query
      * @param string $model_name

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -50,13 +50,13 @@ class PurgeCommand extends Command
     protected $dispatcher;
 
     /**
-     * Fire events when purging?
+     * Dispatch events when purging?
      *
      * This value is used as the default in case there it is not configured.
      *
      * @var bool
      */
-    protected $fire_purge_events = false;
+    protected $dispatch_purge_events = false;
 
     /**
      * Logging instance.
@@ -105,7 +105,7 @@ class PurgeCommand extends Command
     }
 
     /**
-     * Fire the given event for the record being purged.
+     * Dispatch the given event for the record being purged.
      *
      * @param string $event
      * @param string $model_name
@@ -114,13 +114,13 @@ class PurgeCommand extends Command
      *
      * @return mixed
      */
-    protected function firePurgeEvent($event, $model_name, Model $model, $halt = true)
+    protected function dispatchPurgeEvent($event, $model_name, Model $model, $halt = true)
     {
         $event = "garbageman.{$event}: " . $model_name;
 
-        $method = $halt ? 'until' : 'fire';
+        $method = $halt ? 'until' : 'dispatch';
 
-        $this->recordMessage(sprintf("Firing event [%s] with method [%s]", $event, $method), 'debug');
+        $this->recordMessage(sprintf("Dispatching event [%s] with method [%s]", $event, $method), 'debug');
 
         return $this->dispatcher->{$method}($event, $model);
     }
@@ -132,8 +132,11 @@ class PurgeCommand extends Command
      */
     public function handle()
     {
-        $this->fire_purge_events = $this->laravel->make('config')
-                                                 ->get('garbageman.fire_purge_events', $this->fire_purge_events);
+        $this->dispatch_purge_events = $this->laravel->make('config')
+                                                     ->get(
+                                                         'garbageman.dispatch_purge_events',
+                                                         $this->dispatch_purge_events
+                                                     );
 
         $this->logging_level = $this->laravel->make('config')
                                              ->get('garbageman.logging_level', $this->logging_level);
@@ -196,7 +199,7 @@ class PurgeCommand extends Command
     /**
      * Either purge all the records at once or loop through them one by one.
      *
-     * This is to allow events to get fired for each record if needed.
+     * This is to allow events to get dispatchd for each record if needed.
      *
      * @param Builder $query
      * @param string $model_name
@@ -205,22 +208,22 @@ class PurgeCommand extends Command
      */
     protected function purgeRecordsAsConfigured(Builder $query, $model_name)
     {
-        if ($this->fire_purge_events !== true) {
+        if ($this->dispatch_purge_events !== true) {
             $this->recordMessage("Deleting all the records in a single query statement.");
 
             return $query->forceDelete();
         }
 
-        $this->recordMessage("Deleting each record separately and firing events.");
+        $this->recordMessage("Deleting each record separately and dispatching events.");
 
         $records = $query->get();
 
         foreach ($records as $record) {
-            $this->firePurgeEvent('purging', $model_name, $record);
+            $this->dispatchPurgeEvent('purging', $model_name, $record);
 
             $record->forceDelete();
 
-            $this->firePurgeEvent('purged', $model_name, $record);
+            $this->dispatchPurgeEvent('purged', $model_name, $record);
         }
 
         return $records->count();
@@ -248,7 +251,7 @@ class PurgeCommand extends Command
             'error'     => 'error',
             'info'      => 'info',
             'notice'    => 'comment',
-            'warning'   => 'warn', // NOTE: Prior to 5.1.10, there was not a warning, so that is the minimum version
+            'warning'   => 'warn',
         ];
 
         if ($this->supposedToLogAtThisLevel($level, 'log')) {

--- a/src/GarbageManServiceProvider.php
+++ b/src/GarbageManServiceProvider.php
@@ -19,9 +19,12 @@ class GarbageManServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->publishes([
-            realpath(__DIR__ . '/config/garbageman.php') => config_path('garbageman.php'),
-        ], 'config');
+        $this->publishes(
+            [
+                realpath(__DIR__ . '/config/garbageman.php') => config_path('garbageman.php'),
+            ],
+            'config'
+        );
     }
 
     /**
@@ -31,9 +34,12 @@ class GarbageManServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('command.garbageman.purge', function ($app) {
-            return $app->make(PurgeCommand::class);
-        });
+        $this->app->singleton(
+            'command.garbageman.purge',
+            function ($app) {
+                return $app->make(PurgeCommand::class);
+            }
+        );
 
         $this->commands('command.garbageman.purge');
     }

--- a/src/config/garbageman.php
+++ b/src/config/garbageman.php
@@ -49,7 +49,7 @@ return [
     |       'log'     => 6,
     |   ],
     */
-    'logging_level' => [
+    'logging_level'     => [
         'console' => env('GARBAGEMAN_CONSOLE_LOG_LEVEL', 6),
         'log'     => env('GARBAGEMAN_LOG_LEVEL', 6),
     ],
@@ -69,8 +69,7 @@ return [
     | This would purge any ModelOnes that were deleted over 14 days ago and any
     | ModelTwos that are were deleted over 30 days ago.
     */
-    'schedule'      => [
-        //
+    'schedule'          => [//
     ],
 
 ];

--- a/src/config/garbageman.php
+++ b/src/config/garbageman.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Fire events on purge of each record.
+    | Dispatch events on purge of each record.
     |--------------------------------------------------------------------------
     |
     | Allow hook into the purge of each record by throwing events before & after
@@ -23,7 +23,7 @@ return [
     | this false to allow all records per model to get deleted with a single
     | SQL call.
     */
-    'fire_purge_events' => false,
+    'dispatch_purge_events' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -49,7 +49,7 @@ return [
     |       'log'     => 6,
     |   ],
     */
-    'logging_level'     => [
+    'logging_level'         => [
         'console' => env('GARBAGEMAN_CONSOLE_LOG_LEVEL', 6),
         'log'     => env('GARBAGEMAN_LOG_LEVEL', 6),
     ],
@@ -69,7 +69,8 @@ return [
     | This would purge any ModelOnes that were deleted over 14 days ago and any
     | ModelTwos that are were deleted over 30 days ago.
     */
-    'schedule'          => [//
+    'schedule'              => [
+        //
     ],
 
 ];

--- a/tests/Commands/PurgeCommandTest.php
+++ b/tests/Commands/PurgeCommandTest.php
@@ -119,6 +119,7 @@ class PurgeCommandTests extends TestCase
      * @param $line
      *
      * @return array
+     * @throws \ReflectionException
      */
     private function checkVerbosity($line)
     {
@@ -158,7 +159,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -217,7 +218,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -295,7 +296,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -360,7 +361,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -419,13 +420,13 @@ class PurgeCommandTests extends TestCase
      * @test
      * @group unit
      */
-    public function it_deletes_all_expired_records_for_models_with_soft_delete_when_not_configured_to_fire_events()
+    public function it_deletes_all_expired_records_for_models_with_soft_delete_when_not_configured_to_dispatch_events()
     {
         $this->config_mock->shouldReceive('get')
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -594,7 +595,7 @@ class PurgeCommandTests extends TestCase
      * @test
      * @group unit
      */
-    public function it_deletes_each_expired_record_for_models_and_throws_events_with_soft_delete_when_configured_to_fire_events(
+    public function it_deletes_each_expired_record_for_models_and_throws_events_with_soft_delete_when_configured_to_dispatch_events(
     )
     {
 
@@ -602,7 +603,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -764,37 +765,43 @@ class PurgeCommandTests extends TestCase
 
         $this->log_mock->shouldReceive('info')
                        ->twice()
-                       ->with('Deleting each record separately and firing events.')
+                       ->with('Deleting each record separately and dispatching events.')
                        ->andReturnNull();
 
         $this->output_mock->shouldReceive('writeln')
                           ->twice()
                           ->withArgs(
-                              $this->checkVerbosity('<info>Deleting each record separately and firing events.</info>')
+                              $this->checkVerbosity(
+                                  '<info>Deleting each record separately and dispatching events.</info>'
+                              )
                           )
                           ->andReturnNull();
 
         $this->log_mock->shouldReceive('debug')
                        ->once()
-                       ->with('Firing event [garbageman.purging: ModelOne] with method [until]')
+                       ->with('Dispatching event [garbageman.purging: ModelOne] with method [until]')
                        ->andReturnNull();
 
         $this->output_mock->shouldReceive('writeln')
                           ->once()
                           ->withArgs(
-                              $this->checkVerbosity('Firing event [garbageman.purging: ModelOne] with method [until]')
+                              $this->checkVerbosity(
+                                  'Dispatching event [garbageman.purging: ModelOne] with method [until]'
+                              )
                           )
                           ->andReturnNull();
 
         $this->log_mock->shouldReceive('debug')
                        ->once()
-                       ->with('Firing event [garbageman.purged: ModelOne] with method [until]')
+                       ->with('Dispatching event [garbageman.purged: ModelOne] with method [until]')
                        ->andReturnNull();
 
         $this->output_mock->shouldReceive('writeln')
                           ->once()
                           ->withArgs(
-                              $this->checkVerbosity('Firing event [garbageman.purged: ModelOne] with method [until]')
+                              $this->checkVerbosity(
+                                  'Dispatching event [garbageman.purged: ModelOne] with method [until]'
+                              )
                           )
                           ->andReturnNull();
 
@@ -839,7 +846,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -898,7 +905,7 @@ class PurgeCommandTests extends TestCase
                           ->once()
                           ->withArgs(
                               [
-                                  'garbageman.fire_purge_events',
+                                  'garbageman.dispatch_purge_events',
                                   false,
                               ]
                           )
@@ -946,11 +953,11 @@ class PurgeCommandTests extends TestCase
 }
 
 $fake_models = [
-    'ModelOne'      => [
+    'ModelOne' => [
         'forceDelete',
         'onlyTrashed',
     ],
-    'ModelTwo'      => [
+    'ModelTwo' => [
         'forceDelete',
         'onlyTrashed',
     ],

--- a/tests/Commands/PurgeCommandTest.php
+++ b/tests/Commands/PurgeCommandTest.php
@@ -66,7 +66,7 @@ class PurgeCommandTests extends TestCase
      */
     protected $output_mock;
 
-    public function setup() :void
+    public function setup(): void
     {
         parent::setUp();
 
@@ -946,11 +946,11 @@ class PurgeCommandTests extends TestCase
 }
 
 $fake_models = [
-    'ModelOne' => [
+    'ModelOne'      => [
         'forceDelete',
         'onlyTrashed',
     ],
-    'ModelTwo' => [
+    'ModelTwo'      => [
         'forceDelete',
         'onlyTrashed',
     ],

--- a/tests/GarbageManServiceProviderTest.php
+++ b/tests/GarbageManServiceProviderTest.php
@@ -30,7 +30,7 @@ class GarbageManServiceProviderTest extends TestCase
      */
     protected $service_provider;
 
-    public function setup() :void
+    public function setup(): void
     {
         parent::setUp();
 
@@ -77,14 +77,21 @@ class GarbageManServiceProviderTest extends TestCase
 
         $this->application_mock->shouldReceive('singleton')
                                ->once()
-                               ->withArgs([
-                                   'command.garbageman.purge',
-                                   Mockery::on(function ($closure) {
-                                       $this->assertInstanceOf(PurgeCommand::class, $closure($this->application_mock));
+                               ->withArgs(
+                                   [
+                                       'command.garbageman.purge',
+                                       Mockery::on(
+                                           function ($closure) {
+                                               $this->assertInstanceOf(
+                                                   PurgeCommand::class,
+                                                   $closure($this->application_mock)
+                                               );
 
-                                       return true;
-                                   }),
-                               ])
+                                               return true;
+                                           }
+                                       ),
+                                   ]
+                               )
                                ->andReturnNull();
 
         $this->assertNull($this->service_provider->register());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,32 +49,42 @@ abstract class TestCase extends PHPUnitTestCase
             $counter = 0;
 
             $mock->shouldReceive('rewind')
-                 ->andReturnUsing(function () use (& $counter) {
-                     $counter = 0;
-                 });
+                 ->andReturnUsing(
+                     function () use (& $counter) {
+                         $counter = 0;
+                     }
+                 );
 
             $vals = array_values($items);
             $keys = array_values(array_keys($items));
 
             $mock->shouldReceive('valid')
-                 ->andReturnUsing(function () use (& $counter, $vals) {
-                     return isset($vals[$counter]);
-                 });
+                 ->andReturnUsing(
+                     function () use (& $counter, $vals) {
+                         return isset($vals[$counter]);
+                     }
+                 );
 
             $mock->shouldReceive('current')
-                 ->andReturnUsing(function () use (& $counter, $vals) {
-                     return $vals[$counter];
-                 });
+                 ->andReturnUsing(
+                     function () use (& $counter, $vals) {
+                         return $vals[$counter];
+                     }
+                 );
 
             $mock->shouldReceive('key')
-                 ->andReturnUsing(function () use (& $counter, $keys) {
-                     return $keys[$counter];
-                 });
+                 ->andReturnUsing(
+                     function () use (& $counter, $keys) {
+                         return $keys[$counter];
+                     }
+                 );
 
             $mock->shouldReceive('next')
-                 ->andReturnUsing(function () use (& $counter) {
-                     ++$counter;
-                 });
+                 ->andReturnUsing(
+                     function () use (& $counter) {
+                         ++$counter;
+                     }
+                 );
         }
 
         if ($mock instanceof Countable) {


### PR DESCRIPTION
As of `5.4`, `fire` was replaced in favor of `dispatch`, so cleaning up the code to work in same way.